### PR TITLE
Fix menu ordering bug

### DIFF
--- a/client/js/menus/MenuList.jsx
+++ b/client/js/menus/MenuList.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Sortable from 'react-sortablejs';
 import PropTypes from 'prop-types';
+import axios from 'axios';
 import Submenus from './Submenus';
 import MenuUsers from './MenuUsers';
 
@@ -21,7 +22,8 @@ const MenuRow = ({
       <input type="hidden" name="id" defaultValue={id} />
     </td>
     <td className="js_sortable_handle">{id}</td>
-    <td><input type="text" className="form-control" name="menu_title" defaultValue={menuTitle} /></td>
+    <td><input type="text" className="form-control" name="menu_title" defaultValue={menuTitle} />
+    </td>
     <td><input type="text" className="form-control" name="menu_url" defaultValue={menuUrl} /></td>
     <td><input type="text" className="form-control" name="menu_deep" defaultValue={menuDeep} /></td>
     <td>
@@ -120,10 +122,10 @@ export default class MenuList extends React.Component {
   }
 
   onUpdate() {
-    const args = $('#modifyForm').find('input:checked').map((i, e) => {
+    const data = $.map($('#modifyForm').find('input:checked'), (e) => {
       const $tr = $(e).parents('tr');
-      const menuId = $tr.find('input[name=id]').val();
-      const data = {
+      return {
+        id: $tr.find('input[name=id]').val(),
         menu_title: $tr.find('input[name=menu_title]').val(),
         menu_url: $tr.find('input[name=menu_url]').val(),
         menu_deep: $tr.find('input[name=menu_deep]').val(),
@@ -132,18 +134,11 @@ export default class MenuList extends React.Component {
         is_use: $tr.find('select[name=is_use]').val() === 'true' ? '1' : '0',
         is_show: $tr.find('select[name=is_show]').val() === 'true' ? '1' : '0',
       };
-
-      return $.ajax({
-        url: `/super/menus/${menuId}`,
-        type: 'PUT',
-        data,
-      });
     });
 
-    $.when(...args)
-      .done(() => {
-        window.location.reload();
-      });
+    axios.put('/super/menus/', data).then(() => {
+      window.location.reload();
+    });
   }
 
   onSortEnd(evt) {

--- a/client/js/menus/MenuList.jsx
+++ b/client/js/menus/MenuList.jsx
@@ -85,9 +85,11 @@ function checkChangedRow($tr) {
 export default class MenuList extends React.Component {
   constructor() {
     super();
+
     this.showAjaxMenus = this.showAjaxMenus.bind(this);
     this.showMenuUsers = this.showMenuUsers.bind(this);
     this.hideMenuUsers = this.hideMenuUsers.bind(this);
+    this.onSortEnd = this.onSortEnd.bind(this);
 
     this.state = {
       menuUsers: {
@@ -147,14 +149,15 @@ export default class MenuList extends React.Component {
       return;
     }
 
+    const { menus } = this.props;
     const $tbody = $(evt.target);
+    const startIndexToUpdate = Math.min(evt.oldIndex, evt.newIndex);
 
-    const targetIndex = (evt.newIndex > evt.oldIndex) ? evt.newIndex - 1 : evt.newIndex + 1;
-    const newOrder = $tbody.find(`tr:nth-child(${targetIndex + 1}) input[name="menu_order"]`).attr('value');
-
-    const changedRow = $tbody.find(`tr:nth-child(${evt.newIndex + 1})`);
-    changedRow.find('input[name="menu_order"]').val(newOrder);
-    checkChangedRow(changedRow);
+    for (let index = startIndexToUpdate; index < menus.length; index++) {
+      const rowToUpdate = $tbody.find(`tr:nth-child(${index + 1})`);
+      rowToUpdate.find('input[name="menu_order"]').val(index);
+      checkChangedRow(rowToUpdate);
+    }
   }
 
   showAjaxMenus(menuId, menuTitle) {

--- a/client/js/menus/MenuList.jsx
+++ b/client/js/menus/MenuList.jsx
@@ -146,13 +146,18 @@ export default class MenuList extends React.Component {
       return;
     }
 
+    const { menus } = this.props;
     const $tbody = $(evt.target);
-    const startIndexToUpdate = Math.min(evt.newIndex, evt.oldIndex);
-    const endIndexToUpdate = Math.max(evt.newIndex, evt.oldIndex) + 1;
 
-    for (let index = startIndexToUpdate; index < endIndexToUpdate; index++) {
+    for (let index = 0; index < menus.length; index++) {
       const rowToUpdate = $tbody.find(`tr:nth-child(${index + 1})`);
-      rowToUpdate.find('input[name="menu_order"]').val(index);
+      const orderInput = rowToUpdate.find('input[name="menu_order"]');
+
+      if (parseInt(orderInput.val(), 10) === index) {
+        continue;
+      }
+
+      orderInput.val(index);
       checkChangedRow(rowToUpdate);
     }
   }

--- a/client/js/menus/MenuList.jsx
+++ b/client/js/menus/MenuList.jsx
@@ -118,7 +118,7 @@ export default class MenuList extends React.Component {
     });
   }
 
-  onUpdate() {
+  async onUpdate() {
     const data = $.map($('#modifyForm').find('input:checked'), (e) => {
       const $tr = $(e).parents('tr');
       return {
@@ -133,9 +133,8 @@ export default class MenuList extends React.Component {
       };
     });
 
-    axios.put('/super/menus/', data).then(() => {
-      window.location.reload();
-    });
+    await axios.put('/super/menus/', data);
+    window.location.reload();
   }
 
   onSortEnd(evt) {

--- a/client/js/menus/MenuList.jsx
+++ b/client/js/menus/MenuList.jsx
@@ -151,11 +151,11 @@ export default class MenuList extends React.Component {
       return;
     }
 
-    const { menus } = this.props;
     const $tbody = $(evt.target);
-    const startIndexToUpdate = Math.min(evt.oldIndex, evt.newIndex);
+    const startIndexToUpdate = Math.min(evt.newIndex, evt.oldIndex);
+    const endIndexToUpdate = evt.newIndex > evt.oldIndex ? evt.newIndex + 1 : evt.oldIndex;
 
-    for (let index = startIndexToUpdate; index < menus.length; index++) {
+    for (let index = startIndexToUpdate; index < endIndexToUpdate; index++) {
       const rowToUpdate = $tbody.find(`tr:nth-child(${index + 1})`);
       rowToUpdate.find('input[name="menu_order"]').val(index);
       checkChangedRow(rowToUpdate);

--- a/client/js/menus/MenuList.jsx
+++ b/client/js/menus/MenuList.jsx
@@ -22,13 +22,10 @@ const MenuRow = ({
       <input type="hidden" name="id" defaultValue={id} />
     </td>
     <td className="js_sortable_handle">{id}</td>
-    <td><input type="text" className="form-control" name="menu_title" defaultValue={menuTitle} />
-    </td>
+    <td><input type="text" className="form-control" name="menu_title" defaultValue={menuTitle} /></td>
     <td><input type="text" className="form-control" name="menu_url" defaultValue={menuUrl} /></td>
     <td><input type="text" className="form-control" name="menu_deep" defaultValue={menuDeep} /></td>
-    <td>
-      <input type="text" className="form-control" name="menu_order" defaultValue={menuOrder} disabled />
-    </td>
+    <td><input type="text" className="form-control" name="menu_order" defaultValue={menuOrder} disabled /></td>
     <td>
       <select className="form-control" name="is_newtab" defaultValue={isNewtab}>
         <option value>Y</option>

--- a/client/js/menus/MenuList.jsx
+++ b/client/js/menus/MenuList.jsx
@@ -24,7 +24,9 @@ const MenuRow = ({
     <td><input type="text" className="form-control" name="menu_title" defaultValue={menuTitle} /></td>
     <td><input type="text" className="form-control" name="menu_url" defaultValue={menuUrl} /></td>
     <td><input type="text" className="form-control" name="menu_deep" defaultValue={menuDeep} /></td>
-    <td><input type="text" className="form-control" name="menu_order" defaultValue={menuOrder} /></td>
+    <td>
+      <input type="text" className="form-control" name="menu_order" defaultValue={menuOrder} disabled />
+    </td>
     <td>
       <select className="form-control" name="is_newtab" defaultValue={isNewtab}>
         <option value>Y</option>

--- a/client/js/menus/MenuList.jsx
+++ b/client/js/menus/MenuList.jsx
@@ -153,7 +153,7 @@ export default class MenuList extends React.Component {
 
     const $tbody = $(evt.target);
     const startIndexToUpdate = Math.min(evt.newIndex, evt.oldIndex);
-    const endIndexToUpdate = evt.newIndex > evt.oldIndex ? evt.newIndex + 1 : evt.oldIndex;
+    const endIndexToUpdate = Math.max(evt.newIndex, evt.oldIndex) + 1;
 
     for (let index = startIndexToUpdate; index < endIndexToUpdate; index++) {
       const rowToUpdate = $tbody.find(`tr:nth-child(${index + 1})`);

--- a/src/Admin/Controller/MenuControllerProvider.php
+++ b/src/Admin/Controller/MenuControllerProvider.php
@@ -20,7 +20,7 @@ class MenuControllerProvider implements ControllerProviderInterface
 
         $controllers->get('/', [$this, 'menus']);
         $controllers->post('/', [$this, 'createMenu']);
-        $controllers->put('/{menu_id}', [$this, 'updateMenu']);
+        $controllers->put('/', [$this, 'updateMenus']);
 
         $controllers->get('/{menu_id}/submenus', [$this, 'submenus']);
         $controllers->post('/{menu_id}/submenus', [$this, 'createSubmenu']);
@@ -81,21 +81,12 @@ class MenuControllerProvider implements ControllerProviderInterface
         return $app->redirect('/super/menus');
     }
 
-    public function updateMenu(CmsApplication $app, Request $request, $menu_id)
+    public function updateMenus(CmsApplication $app, Request $request)
     {
-        $menu = [
-            'id' => $menu_id,
-            'menu_title' => $request->get('menu_title'),
-            'menu_url' => $request->get('menu_url'),
-            'menu_order' => $request->get('menu_order'),
-            'menu_deep' => $request->get('menu_deep', 0),
-            'is_newtab' => $request->get('is_newtab', 0),
-            'is_use' => $request->get('is_use', 0),
-            'is_show' => $request->get('is_show', 0),
-        ];
+        $menus = $request->request->all();
 
         try {
-            AdminMenuService::updateMenu($menu);
+            AdminMenuService::updateMenus($menus);
         } catch (\Exception $e) {
             if (!is_a($e, 'HttpException')) {
                 $e = new HttpException(Response::HTTP_INTERNAL_SERVER_ERROR, $e->getMessage());

--- a/src/Admin/MenuService.php
+++ b/src/Admin/MenuService.php
@@ -76,6 +76,15 @@ class MenuService
         });
     }
 
+    public static function updateMenus(array $menus)
+    {
+        DB::connection()->transaction(function () use ($menus) {
+            foreach ($menus as $menu) {
+                self::updateMenu($menu);
+            }
+        });
+    }
+
     public static function getMenuAjaxList($menu_id)
     {
         return AdminMenu::find($menu_id)->ajaxMenus->toArray();

--- a/src/app.php
+++ b/src/app.php
@@ -6,6 +6,7 @@ use Moriony\Silex\Provider\SentryServiceProvider;
 use Ridibooks\Cms\Admin\WebpackManifestVersionStrategy;
 use Ridibooks\Cms\CmsApplication;
 use Symfony\Component\Asset\PathPackage;
+use Symfony\Component\HttpFoundation\Request;
 
 $app = new CmsApplication($config);
 $app->register(new CapsuleServiceProvider(), [
@@ -28,6 +29,14 @@ $app->extend('twig', function (\Twig_Environment $twig) use ($app) {
     }));
 
     return $twig;
+});
+
+// decode json content to array
+$app->before(function (Request $request) {
+    if ($request->getContentType() === 'json') {
+        $data = json_decode($request->getContent(), true);
+        $request->request->replace(is_array($data) ? $data : []);
+    }
 });
 
 return $app;


### PR DESCRIPTION
https://app.asana.com/0/235684600038401/600028318666684/f

메뉴 순서 편집 시 순서 값이 중복되거나 잘못된 값으로 설정되는 버그를 수정했습니다. 순서변경을 하면 순서 값이 올바르지 않은 메뉴의 값도 수정되도록 했습니다. 또한 한번의 API 호출로 여러 메뉴 업데이트를 한번에 하도록 했습니다.