### PR TITLE
Apply CMS UI

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -4,6 +4,69 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@fortawesome/fontawesome": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome/-/fontawesome-1.1.5.tgz",
+      "integrity": "sha512-WAgbcVs7/YTxq7RK/dhyoJPzaIZpOQnStyO5s1sj0rZa0J1ScXYoGPmsP1ec6qM/BhDjRVB228xr2DiCPTHRCA==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "0.1.4"
+      }
+    },
+    "@fortawesome/fontawesome-common-types": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.1.4.tgz",
+      "integrity": "sha512-JEgIoqh9HAQWul8CVLrOmWUI8nUQfCJZygRJ1Cr2H/O3+pCpVszW199cIpc7k7Nr1HJtLD77AUZVnxaKllx7AQ=="
+    },
+    "@fortawesome/fontawesome-free-solid": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free-solid/-/fontawesome-free-solid-5.0.10.tgz",
+      "integrity": "sha512-RFxCG49xJcU7NwcEjAnJaerlzCzCX5sx9HdbHt3E1zML2skwmAZ2PwqyEfuT0iW2ZfYyx6SU1Zf0GUa7FL6f/A==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "0.1.4"
+      }
+    },
+    "@fortawesome/react-fontawesome": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.0.18.tgz",
+      "integrity": "sha512-ZSO55oWtGSZFvoJW0gvhlYndKvHqmMj/27qTrJOT4DaxQ4Fcc90h/BVEED6IktzBqEunUF8aP+bwU5Og1I0fnQ==",
+      "requires": {
+        "humps": "2.0.1"
+      }
+    },
+    "@ridi/cms-ui": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@ridi/cms-ui/-/cms-ui-0.2.2.tgz",
+      "integrity": "sha512-9WT/qkNOX9wsWAvm+kDcRenilmUAv1WZZ5kZBvRwjJeeyU1fQePvpMqdFxmS0YYxMTjehkCVEpJnx++tl2ol7w==",
+      "requires": {
+        "@fortawesome/fontawesome": "1.1.5",
+        "@fortawesome/fontawesome-free-solid": "5.0.10",
+        "@fortawesome/react-fontawesome": "0.0.18",
+        "bootstrap": "4.1.0",
+        "classnames": "2.2.5",
+        "lodash": "4.17.5",
+        "prop-types": "15.6.1",
+        "react": "16.3.1",
+        "react-dom": "16.3.1",
+        "reactstrap": "5.0.0"
+      },
+      "dependencies": {
+        "bootstrap": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.1.0.tgz",
+          "integrity": "sha512-kCo82nE8qYVfOa/Z3hL98CPgPIEkh6iPdiJrUJMQ9n9r0+6PEET7cmhLlV0XVYmEj5QtKIOaSGMLxy5jSFhKog=="
+        },
+        "prop-types": {
+          "version": "15.6.1",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
+          "integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
+          "requires": {
+            "fbjs": "0.8.16",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1"
+          }
+        }
+      }
+    },
     "@ridi/eslint-config": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@ridi/eslint-config/-/eslint-config-4.0.0.tgz",
@@ -5281,6 +5344,11 @@
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
       "dev": true
     },
+    "humps": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/humps/-/humps-2.0.1.tgz",
+      "integrity": "sha1-3QLqYIG9BWjcXQcxhEY5V7qe+ao="
+    },
     "iconv-lite": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
@@ -6506,11 +6574,26 @@
       "integrity": "sha1-9HGh2khr5g9quVXRcRVSPdHSVdU=",
       "dev": true
     },
+    "lodash.isfunction": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
+      "integrity": "sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw=="
+    },
+    "lodash.isobject": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz",
+      "integrity": "sha1-PI+41bW/S/kK4G4U8qUwpO2TXh0="
+    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
       "dev": true
+    },
+    "lodash.tonumber": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.tonumber/-/lodash.tonumber-4.0.3.tgz",
+      "integrity": "sha1-C5azGzVnJ5Prf1pj7nkfG56QJdk="
     },
     "lodash.uniq": {
       "version": "4.5.0",
@@ -7843,6 +7926,11 @@
       "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
       "dev": true
     },
+    "popper.js": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.14.3.tgz",
+      "integrity": "sha1-FDj5jQRqz3tNeM1QK/QYrGTU8JU="
+    },
     "portfinder": {
       "version": "1.0.13",
       "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.13.tgz",
@@ -8765,12 +8853,57 @@
         "warning": "3.0.0"
       }
     },
+    "react-popper": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-0.8.3.tgz",
+      "integrity": "sha1-D3MzMTfJ+wr27EB00tBYWgoEYeE=",
+      "requires": {
+        "popper.js": "1.14.3",
+        "prop-types": "15.6.0"
+      }
+    },
     "react-sortablejs": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/react-sortablejs/-/react-sortablejs-1.3.6.tgz",
       "integrity": "sha512-EZnoOnwSJfDrK25O21U/uLbokWFW0h4d9QyMaTI9GXGc+MQZXUUKD/OlfUmqrgJL2f8XasqE2XWVSaPW677PDQ==",
       "requires": {
         "prop-types": "15.6.0"
+      }
+    },
+    "react-transition-group": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.3.1.tgz",
+      "integrity": "sha512-hu4/LAOFSKjWt1+1hgnOv3ldxmt6lvZGTWz4KUkFrqzXrNDIVSu6txIcPszw7PNduR8en9YTN55JLRyd/L1ZiQ==",
+      "requires": {
+        "dom-helpers": "3.3.1",
+        "loose-envify": "1.3.1",
+        "prop-types": "15.6.1"
+      },
+      "dependencies": {
+        "prop-types": {
+          "version": "15.6.1",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
+          "integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
+          "requires": {
+            "fbjs": "0.8.16",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1"
+          }
+        }
+      }
+    },
+    "reactstrap": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/reactstrap/-/reactstrap-5.0.0.tgz",
+      "integrity": "sha512-y0eju/LAK7gbEaTFfq2iW92MF7/5Qh0tc1LgYr2mg92IX8NodGc03a+I+cp7bJ0VXHAiLy0bFL9UP89oSm4cBg==",
+      "requires": {
+        "classnames": "2.2.5",
+        "lodash.isfunction": "3.0.9",
+        "lodash.isobject": "3.0.2",
+        "lodash.tonumber": "4.0.3",
+        "prop-types": "15.6.0",
+        "react-popper": "0.8.3",
+        "react-transition-group": "2.3.1"
       }
     },
     "read-chunk": {

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -34,9 +34,9 @@
       }
     },
     "@ridi/cms-ui": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@ridi/cms-ui/-/cms-ui-0.2.2.tgz",
-      "integrity": "sha512-9WT/qkNOX9wsWAvm+kDcRenilmUAv1WZZ5kZBvRwjJeeyU1fQePvpMqdFxmS0YYxMTjehkCVEpJnx++tl2ol7w==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@ridi/cms-ui/-/cms-ui-0.2.3.tgz",
+      "integrity": "sha512-Z4wojFSZZ/9rF/lGWV28NDZmdyV7TJEQA5lCQUA1d5ibkr0vB+9JfK2FeXiDnsIHox13Etm30GY0oIT7gN0zXA==",
       "requires": {
         "@fortawesome/fontawesome": "1.1.5",
         "@fortawesome/fontawesome-free-solid": "5.0.10",

--- a/client/package.json
+++ b/client/package.json
@@ -7,6 +7,7 @@
     "url": "git+https://github.com/ridibooks/cms-admin.git"
   },
   "dependencies": {
+    "@ridi/cms-ui": "^0.2.2",
     "axios": "^0.16.2",
     "bootstrap": "^3.3.7",
     "jquery": "^3.2.1",

--- a/client/package.json
+++ b/client/package.json
@@ -7,7 +7,7 @@
     "url": "git+https://github.com/ridibooks/cms-admin.git"
   },
   "dependencies": {
-    "@ridi/cms-ui": "^0.2.2",
+    "@ridi/cms-ui": "^0.2.3",
     "axios": "^0.16.2",
     "bootstrap": "^3.3.7",
     "jquery": "^3.2.1",

--- a/client/src/base.css
+++ b/client/src/base.css
@@ -1,3 +1,18 @@
-body {
-  padding: 1rem 0;
+html {
+  font-size: 16px;
+}
+
+#main_container {
+  display: flex;
+  flex-flow: row nowrap;
+  padding: .5rem;
+}
+
+#menu_container {
+  margin: .5rem;
+}
+
+#content_container {
+  flex: 1;
+  margin: .5rem;
 }

--- a/client/src/base.jsx
+++ b/client/src/base.jsx
@@ -1,3 +1,6 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
 import $ from 'jquery';
 import 'bootstrap';
 import 'bootstrap/dist/css/bootstrap.min.css';
@@ -5,7 +8,13 @@ import 'bootstrap/dist/css/bootstrap.min.css';
 import 'select2/dist/js/select2.full';
 import 'select2/dist/css/select2.min.css';
 
+import { Menu } from '@ridi/cms-ui';
 import './base.css';
+
+ReactDOM.render(
+  <Menu items={window.menuItems} />,
+  document.getElementById('menu_container'),
+);
 
 $(() => {
   const $menuSelect = $('.menu_select');

--- a/client/src/base.jsx
+++ b/client/src/base.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 
-import $ from 'jquery';
 import 'bootstrap';
 import 'bootstrap/dist/css/bootstrap.min.css';
 
@@ -15,14 +14,3 @@ ReactDOM.render(
   <Menu items={window.menuItems} />,
   document.getElementById('menu_container'),
 );
-
-$(() => {
-  const $menuSelect = $('.menu_select');
-  $menuSelect.select2({
-    placeholder: '메뉴를 검색하세요',
-  });
-
-  $menuSelect.on('select2:select', (e) => {
-    window.location.href = e.params.data.id;
-  });
-});

--- a/views/base.twig
+++ b/views/base.twig
@@ -14,31 +14,28 @@
   {% endblock %}
 
   {% block script %}
+    <script>
+      window.menuItems = {{ menus|json_encode|raw }};
+    </script>
     <script src="{{ asset('commons.js') }}"></script>
   {% endblock %}
 </head>
-<body>
-  <div class="container-fluid">
-    <div class="row">
-      <div class="col-xs-12 col-lg-2">
-        {% include '/comm/left_menu_new.twig' %}
-      </div>
+<body id="main_container">
+  <div id="menu_container"></div>
 
-      <div class="col-xs-12 col-lg-10">
-        <h3>{{ block('title') }}</h3>
-        <hr>
+  <div id="content_container">
+    <h3>{{ block('title') }}</h3>
+    <hr>
 
-        {% for type, messages in app.flashes %}
-          {% for message in messages %}
-            <div class="alert alert-{{ type }} alert-dismissible" role="alert">
-              {{ message }}
-            </div>
-          {% endfor %}
-        {% endfor %}
+    {% for type, messages in app.flashes %}
+      {% for message in messages %}
+        <div class="alert alert-{{ type }} alert-dismissible" role="alert">
+          {{ message }}
+        </div>
+      {% endfor %}
+    {% endfor %}
 
-        <div id="content"></div>
-      </div>
-    </div>
+    <div id="content"></div>
   </div>
 
   {% block bottom_script %}


### PR DESCRIPTION
https://app.asana.com/0/235684600038401/623922705289911/f

CMS UI를 적용했습니다. Twig에서 직접 로드해보려고 했는데, `node_modules` 디렉터리를 통째로 노출하지 않는 방법이 간단히 떠오르지 않아 일단 React 쪽에서 메뉴 렌더링을 했습니다. ~~한가지 아쉬운 점은 빌드 후 `common.js` 파일이 3MB에 달한다는 것입니다...~~ <-- CMS UI 업데이트 후 `common.js` 파일 크기가 1.94MB가 되었습니다.