### PR TITLE
Load cms-ui from CDN

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -4,72 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@fortawesome/fontawesome": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome/-/fontawesome-1.1.8.tgz",
-      "integrity": "sha512-c0/MtkPVT0fmiFcCyYoPjkG9PkMOvfrZw2+0BaJ+Rh6UEcK1AR/LaRgrHHjUkbAbs9LXxQJhFS8CJ4uSnK2+JA==",
-      "requires": {
-        "@fortawesome/fontawesome-common-types": "0.1.7"
-      }
-    },
-    "@fortawesome/fontawesome-common-types": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.1.7.tgz",
-      "integrity": "sha512-ego8jRVSHfq/iq4KRZJKQeUAdi3ZjGNrqw4oPN3fNdvTBnLCSntwVCnc37bsAJP9UB8MhrTfPnZYxkv2vpS4pg=="
-    },
-    "@fortawesome/fontawesome-free-solid": {
-      "version": "5.0.13",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free-solid/-/fontawesome-free-solid-5.0.13.tgz",
-      "integrity": "sha512-b+krVnqkdDt52Yfev0x0ZZgtxBQsLw00Zfa3uaVWIDzpNZVtrEXuxldUSUaN/ihgGhSNi8VpvDAdNPVgCKOSxw==",
-      "requires": {
-        "@fortawesome/fontawesome-common-types": "0.1.7"
-      }
-    },
-    "@fortawesome/react-fontawesome": {
-      "version": "0.0.19",
-      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.0.19.tgz",
-      "integrity": "sha512-bZe2wGeSMNu/HfdW1/xvrZKha8Rwr8ceO57JHasWHhvQBcDiG7bSC1XwrdMVr9rj8tiHyvQhPc5yMPUeUtMAKA==",
-      "requires": {
-        "humps": "2.0.1",
-        "prop-types": "15.6.0"
-      }
-    },
-    "@ridi/cms-ui": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@ridi/cms-ui/-/cms-ui-0.3.2.tgz",
-      "integrity": "sha512-XdRkkuzUOxrJOAaWO4H/h7WOt5B7bK7VUJztfNSi+CZNNfXzMtcNcQxA1GojJXd2XGNNmJ36kO+PAsAPbAys0w==",
-      "requires": {
-        "@fortawesome/fontawesome": "1.1.8",
-        "@fortawesome/fontawesome-free-solid": "5.0.13",
-        "@fortawesome/react-fontawesome": "0.0.19",
-        "bootstrap": "4.1.1",
-        "classnames": "2.2.5",
-        "es6-class-bind-all": "1.0.0",
-        "lodash": "4.17.5",
-        "prop-types": "15.6.1",
-        "react": "16.3.1",
-        "react-dom": "16.3.1",
-        "reactstrap": "5.0.0",
-        "recompose": "0.27.1"
-      },
-      "dependencies": {
-        "bootstrap": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.1.1.tgz",
-          "integrity": "sha512-SpiDSOcbg4J/PjVSt4ny5eY6j74VbVSjROY4Fb/WIUXBV9cnb5luyR4KnPvNoXuGnBK1T+nJIWqRsvU3yP8Mcg=="
-        },
-        "prop-types": {
-          "version": "15.6.1",
-          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
-          "integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
-          "requires": {
-            "fbjs": "0.8.16",
-            "loose-envify": "1.3.1",
-            "object-assign": "4.1.1"
-          }
-        }
-      }
-    },
     "@ridi/eslint-config": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@ridi/eslint-config/-/eslint-config-4.0.0.tgz",
@@ -1874,11 +1808,6 @@
         "supports-color": "2.0.0"
       }
     },
-    "change-emitter": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/change-emitter/-/change-emitter-0.1.6.tgz",
-      "integrity": "sha1-6LL+PX8at9aaMhma/5HqaTFAlRU="
-    },
     "chardet": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
@@ -2984,11 +2913,6 @@
         "is-date-object": "1.0.1",
         "is-symbol": "1.0.1"
       }
-    },
-    "es6-class-bind-all": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es6-class-bind-all/-/es6-class-bind-all-1.0.0.tgz",
-      "integrity": "sha512-AN9P5OPZlfLbnh3TGFyLys/DTU32ToEy9VPdqpnQI6oleHiCG5KmI+lz1SVsyn7uCAA73UxlnsmM7aXZjs1Z3w=="
     },
     "escape-html": {
       "version": "1.0.3",
@@ -5250,11 +5174,6 @@
         "minimalistic-crypto-utils": "1.0.1"
       }
     },
-    "hoist-non-react-statics": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.0.tgz",
-      "integrity": "sha512-6Bl6XsDT1ntE0lHbIhr4Kp2PGcleGZ66qu5Jqk8lc0Xc/IeG6gVLmwUGs/K0Us+L8VWoKgj0uWdPMataOsm31w=="
-    },
     "home-or-tmp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
@@ -5361,11 +5280,6 @@
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
       "dev": true
-    },
-    "humps": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/humps/-/humps-2.0.1.tgz",
-      "integrity": "sha1-3QLqYIG9BWjcXQcxhEY5V7qe+ao="
     },
     "iconv-lite": {
       "version": "0.4.19",
@@ -6592,26 +6506,11 @@
       "integrity": "sha1-9HGh2khr5g9quVXRcRVSPdHSVdU=",
       "dev": true
     },
-    "lodash.isfunction": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
-      "integrity": "sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw=="
-    },
-    "lodash.isobject": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz",
-      "integrity": "sha1-PI+41bW/S/kK4G4U8qUwpO2TXh0="
-    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
       "dev": true
-    },
-    "lodash.tonumber": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/lodash.tonumber/-/lodash.tonumber-4.0.3.tgz",
-      "integrity": "sha1-C5azGzVnJ5Prf1pj7nkfG56QJdk="
     },
     "lodash.uniq": {
       "version": "4.5.0",
@@ -7944,11 +7843,6 @@
       "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
       "dev": true
     },
-    "popper.js": {
-      "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.14.3.tgz",
-      "integrity": "sha1-FDj5jQRqz3tNeM1QK/QYrGTU8JU="
-    },
     "portfinder": {
       "version": "1.0.13",
       "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.13.tgz",
@@ -8859,11 +8753,6 @@
         "prop-types": "15.6.0"
       }
     },
-    "react-lifecycles-compat": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
-    },
     "react-overlays": {
       "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-0.7.4.tgz",
@@ -8876,57 +8765,12 @@
         "warning": "3.0.0"
       }
     },
-    "react-popper": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-0.8.3.tgz",
-      "integrity": "sha1-D3MzMTfJ+wr27EB00tBYWgoEYeE=",
-      "requires": {
-        "popper.js": "1.14.3",
-        "prop-types": "15.6.0"
-      }
-    },
     "react-sortablejs": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/react-sortablejs/-/react-sortablejs-1.3.6.tgz",
       "integrity": "sha512-EZnoOnwSJfDrK25O21U/uLbokWFW0h4d9QyMaTI9GXGc+MQZXUUKD/OlfUmqrgJL2f8XasqE2XWVSaPW677PDQ==",
       "requires": {
         "prop-types": "15.6.0"
-      }
-    },
-    "react-transition-group": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.3.1.tgz",
-      "integrity": "sha512-hu4/LAOFSKjWt1+1hgnOv3ldxmt6lvZGTWz4KUkFrqzXrNDIVSu6txIcPszw7PNduR8en9YTN55JLRyd/L1ZiQ==",
-      "requires": {
-        "dom-helpers": "3.3.1",
-        "loose-envify": "1.3.1",
-        "prop-types": "15.6.1"
-      },
-      "dependencies": {
-        "prop-types": {
-          "version": "15.6.1",
-          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
-          "integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
-          "requires": {
-            "fbjs": "0.8.16",
-            "loose-envify": "1.3.1",
-            "object-assign": "4.1.1"
-          }
-        }
-      }
-    },
-    "reactstrap": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/reactstrap/-/reactstrap-5.0.0.tgz",
-      "integrity": "sha512-y0eju/LAK7gbEaTFfq2iW92MF7/5Qh0tc1LgYr2mg92IX8NodGc03a+I+cp7bJ0VXHAiLy0bFL9UP89oSm4cBg==",
-      "requires": {
-        "classnames": "2.2.5",
-        "lodash.isfunction": "3.0.9",
-        "lodash.isobject": "3.0.2",
-        "lodash.tonumber": "4.0.3",
-        "prop-types": "15.6.0",
-        "react-popper": "0.8.3",
-        "react-transition-group": "2.3.1"
       }
     },
     "read-chunk": {
@@ -9039,26 +8883,6 @@
       "dev": true,
       "requires": {
         "resolve": "1.5.0"
-      }
-    },
-    "recompose": {
-      "version": "0.27.1",
-      "resolved": "https://registry.npmjs.org/recompose/-/recompose-0.27.1.tgz",
-      "integrity": "sha512-p7xsyi/rfNjHfdP7vPU02uSFa+Q1eHhjKrvO+3+kRP4Ortj+MxEmpmd+UQtBGM2D2iNAjzNI5rCyBKp9Ob5McA==",
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "change-emitter": "0.1.6",
-        "fbjs": "0.8.16",
-        "hoist-non-react-statics": "2.5.0",
-        "react-lifecycles-compat": "3.0.4",
-        "symbol-observable": "1.2.0"
-      },
-      "dependencies": {
-        "symbol-observable": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-          "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
-        }
       }
     },
     "redent": {

--- a/client/package.json
+++ b/client/package.json
@@ -7,7 +7,6 @@
     "url": "git+https://github.com/ridibooks/cms-admin.git"
   },
   "dependencies": {
-    "@ridi/cms-ui": "^0.3.2",
     "axios": "^0.16.2",
     "bootstrap": "^3.3.7",
     "jquery": "^3.2.1",

--- a/client/src/base.jsx
+++ b/client/src/base.jsx
@@ -1,16 +1,7 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
-
 import 'bootstrap';
 import 'bootstrap/dist/css/bootstrap.min.css';
 
 import 'select2/dist/js/select2.full';
 import 'select2/dist/css/select2.min.css';
 
-import { Menu } from '@ridi/cms-ui';
 import './base.css';
-
-ReactDOM.render(
-  <Menu items={window.menuItems} />,
-  document.getElementById('menu_container'),
-);

--- a/views/base.twig
+++ b/views/base.twig
@@ -14,7 +14,7 @@
   {% endblock %}
 
   {% block script %}
-    <script src="https://cdn.jsdelivr.net/npm/@ridi/cms-ui@^0.3/dist/cms-ui.var.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@ridi/cms-ui@0.3/dist/cms-ui.var.js"></script>
     <script src="{{ asset('commons.js') }}"></script>
   {% endblock %}
 </head>

--- a/views/base.twig
+++ b/views/base.twig
@@ -14,14 +14,25 @@
   {% endblock %}
 
   {% block script %}
-    <script>
-      window.menuItems = {{ menus|json_encode|raw }};
-    </script>
+    <script src="https://cdn.jsdelivr.net/npm/@ridi/cms-ui@^0.3/dist/cms-ui.var.js"></script>
     <script src="{{ asset('commons.js') }}"></script>
   {% endblock %}
 </head>
 <body>
   <div id="menu_container"></div>
+
+  <script>
+    (function renderMenu() {
+      var menuComponent = CmsUi.Menu;
+      var menuProps = {
+        items: {{ menus|json_encode|raw }}
+      };
+      var menuElement = CmsUi.createElement(menuComponent, menuProps);
+      var menuContainer = document.getElementById('menu_container');
+
+      CmsUi.render(menuElement, menuContainer);
+    })();
+  </script>
 
   <h3>{{ block('title') }}</h3>
   <hr>


### PR DESCRIPTION
To leverage the semantic versioning (e.g. for auto-upgrade), use CDN for loading CMS UI rather than npm. (When using npm, upgrading must be explicitly done because `package-lock.json` forces to install the specific versions of the packages.)