### PR TITLE
Updated a legacy; gitlab.ridi.io -> gitlab.com

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -11,4 +11,4 @@ curl -X POST \
     -F "variables[ENV]=${CI_TRIGGER_ENV}" \
     -F "variables[TARGET]=${CI_TRIGGER_TARGET}" \
     -F "variables[DOCKER_TAG]=${CI_TRIGGER_TAG}" \
-    https://gitlab.ridi.io/api/v4/projects/373/trigger/pipeline
+    https://gitlab.com/api/v4/projects/8980863/trigger/pipeline


### PR DESCRIPTION
## 개요 
https://travis-ci.org/ridi/cms-admin/jobs/498558836
deploy 시 기존에 CI 트리거 url이 gitlab.ridi.io에서 gitlab.com 마이그레이션 진행 후 변경되어  URL이 유효하지 않습니다

 ## 변경사항 
gitlab ci 트리거 url 을 변경하였습니다. 
  기존: gitlab.ridi.io
  변경: gitlab.com
